### PR TITLE
fix for issue #86

### DIFF
--- a/src/main/java/com/mailjet/client/MailjetClient.java
+++ b/src/main/java/com/mailjet/client/MailjetClient.java
@@ -213,7 +213,7 @@ public class MailjetClient {
                 throw new MailjetSocketTimeoutException("Socket Timeout");
             }
 
-            json = (response.getBodyAsString() != null ?
+            json = (response.getBodyAsString() != null && !(response.getBodyAsString().equals("")) ?
                     response.getBodyAsString() : new JSONObject().put("status", response.getStatus()).toString());
             return new MailjetResponse(response.getStatus(), new JSONObject(json));
         } catch (MalformedURLException ex) {


### PR DESCRIPTION
If and empty Body response when posting data, the only the status is set in the JSON Response.

To "easily" reproduce a 400 error, send a standard V3.1 payload using the default V3 API client configuration. See #86 for more informations.