### PR TITLE
Http client timeouts setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/*
 /.settings/org.eclipse.core.resources.prefs
 /.settings/org.eclipse.jdt.core.prefs
 /.settings/org.eclipse.m2e.core.prefs
+.idea/
+mailjet-client.iml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mailjet</groupId>
     <artifactId>mailjet-client</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+    <version>4.3.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Mailjet Client</name>
     <description>A Mailjet API Client</description>

--- a/src/main/java/com/mailjet/client/ClientOptions.java
+++ b/src/main/java/com/mailjet/client/ClientOptions.java
@@ -41,6 +41,7 @@ public class ClientOptions {
   }
 
   public ClientOptions(String version, Integer connectionTimeout, Integer readTimeout) {
+    this.baseUrl = ClientOptions.defaultBaseURL;
     this.version = version;
     this.connectionTimeout = connectionTimeout;
     this.readTimeout = readTimeout;
@@ -54,6 +55,8 @@ public class ClientOptions {
   }
 
   public ClientOptions(Integer connectionTimeout, Integer readTimeout) {
+    this.baseUrl = ClientOptions.defaultBaseURL;
+    this.version = ClientOptions.defaultVersion;
     this.connectionTimeout = connectionTimeout;
     this.readTimeout = readTimeout;
   }

--- a/src/main/java/com/mailjet/client/ClientOptions.java
+++ b/src/main/java/com/mailjet/client/ClientOptions.java
@@ -16,20 +16,46 @@ public class ClientOptions {
 
   private String baseUrl;
   private String version;
+  private Integer connectionTimeout;
+  private Integer readTimeout;
 
   public ClientOptions() {
     this.baseUrl = ClientOptions.defaultBaseURL;
     this.version = ClientOptions.defaultVersion;
+    this.readTimeout = null;
+    this.connectionTimeout = null;
   }
 
   public ClientOptions(String version, String baseUrl) {
     this.baseUrl = baseUrl;
     this.version = version;
+    this.readTimeout = null;
+    this.connectionTimeout = null;
   }
 
   public ClientOptions(String version) {
     this.baseUrl = ClientOptions.defaultBaseURL;
     this.version = version;
+    this.readTimeout = null;
+    this.connectionTimeout = null;
+  }
+
+  public ClientOptions(String version, Integer connectionTimeout, Integer readTimeout) {
+    this.version = version;
+    this.connectionTimeout = connectionTimeout;
+    this.readTimeout = readTimeout;
+  }
+
+  public ClientOptions( String version, String baseUrl,Integer connectionTimeout, Integer readTimeout) {
+    this.baseUrl = baseUrl;
+    this.version = version;
+    this.connectionTimeout = connectionTimeout;
+    this.readTimeout = readTimeout;
+  }
+
+  public ClientOptions(Integer connectionTimeout, Integer readTimeout) {
+    this.connectionTimeout = connectionTimeout;
+    this.readTimeout = readTimeout;
   }
 
   public String getBaseUrl() {
@@ -40,4 +66,11 @@ public class ClientOptions {
     return this.version;
   }
 
+  public Integer getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public Integer getReadTimeout() {
+    return readTimeout;
+  }
 }

--- a/src/main/java/com/mailjet/client/MailjetClient.java
+++ b/src/main/java/com/mailjet/client/MailjetClient.java
@@ -353,6 +353,15 @@ public class MailjetClient {
 
     private void setOptions(ClientOptions options) {
         this._options = options;
+
+        final Integer connectionTimeout = options.getConnectionTimeout();
+        if (connectionTimeout != null) {
+            this._client.setConnectionTimeout(connectionTimeout.intValue());
+        }
+        final Integer readTimeout = options.getReadTimeout();
+        if (readTimeout != null) {
+            this._client.setReadTimeout(readTimeout.intValue());
+        }
     }
 
     private String createUrl() {


### PR DESCRIPTION
Add the ability to set connection and read timeouts of the inner http client through the ClientOptions object.
By default ClientOptions timeouts are null and it does not set anything in the inner _clients (so it keeps the default values)