### PR TITLE
Add setRequestLogger-method to client-API.

### DIFF
--- a/src/main/java/com/mailjet/client/MailjetClient.java
+++ b/src/main/java/com/mailjet/client/MailjetClient.java
@@ -208,6 +208,14 @@ public class MailjetClient {
 	}
 
     /**
+     * Set the request logger
+     * @param logger
+     */
+	public void setRequestLogger(RequestLogger logger) {
+        _client.setRequestLogger(logger);
+    }
+
+    /**
      * Set the debug level
      * @param debug:
      *  VERBOSE_DEBUG: prints every URL/payload.


### PR DESCRIPTION
Background: turbomanage http-client will use the default ConsoleRequestLogger (logs everything), if a RequestHandler is supplied to the MailjetClient constructor.
In practice this meant that it was not possible to use a custom handler without logging every request.

This commit fix the issue by exposing a setter for the client's request logger.