### PR TITLE
Bugfix/http response status 400 with JSON should not raise exception

### DIFF
--- a/src/main/java/com/mailjet/client/MailjetResponseUtil.java
+++ b/src/main/java/com/mailjet/client/MailjetResponseUtil.java
@@ -8,7 +8,7 @@ import com.mailjet.client.errors.MailjetSocketTimeoutException;
 import com.turbomanage.httpclient.HttpResponse;
 
 /**
- * 
+ *
  * @author y.vanov
  *
  */
@@ -37,7 +37,9 @@ public final class MailjetResponseUtil {
 				throw new MailjetServerException(INTERNAL_SERVER_ERROR_GENERAL_EXCEPTION);
 			}
 		} else if (response.getStatus() >= BAD_REQUEST_ERROR_STATUS) { // Errors between 400 and 500, exclude 429
-			throw new MailjetServerException(response.getBodyAsString());
+			if (!isValidJSON(response.getBodyAsString())) {
+				throw new MailjetServerException(response.getBodyAsString());
+			}
 		}
 	}
 


### PR DESCRIPTION
Quick fix of #121 

Don't raise exception if the response body is valid JSON

Situations where this can araise is with the bulk API, where the API
returns 400 if one or more emails has some sort of error. The other
emails in the bulk can still be successful. We should therefore not
raise an exception if the response is valid JSON.