### PR TITLE
Bump junit version to 4.13 and reduce junit scope to test #116

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <type>jar</type>
+            <version>4.13</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Reduce junit scope.
Currently it is not possible to run project with just junit5 on intellij because the junit4 tests are imported as jar to the projects.