### PR TITLE
Set read timeout to appropriate default

### DIFF
--- a/src/main/java/com/mailjet/client/ClientOptions.java
+++ b/src/main/java/com/mailjet/client/ClientOptions.java
@@ -13,7 +13,7 @@ public class ClientOptions {
 
   private static String defaultBaseURL = "https://api.mailjet.com";
   private static String defaultVersion = "v3";
-  private static Integer defaultTimeout = 10000;
+  private static Integer defaultTimeout = 8000;
 
   private String baseUrl;
   private String version;

--- a/src/main/java/com/mailjet/client/ClientOptions.java
+++ b/src/main/java/com/mailjet/client/ClientOptions.java
@@ -13,7 +13,7 @@ public class ClientOptions {
 
   private static String defaultBaseURL = "https://api.mailjet.com";
   private static String defaultVersion = "v3";
-  private static Integer defaultTimeout = 10;
+  private static Integer defaultTimeout = 10000;
 
   private String baseUrl;
   private String version;


### PR DESCRIPTION
I believe the default read timeout was mistakenly set to 10 milliseconds, which breaks most applications that do not explicitly specify a read timeout. This PR sets the default value to 10 seconds.