### PR TITLE
downgrade oktthp to latest 3.12 version, fixes #144

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.0</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.9.0</version>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/mailjet/client/MailjetClient.java
+++ b/src/main/java/com/mailjet/client/MailjetClient.java
@@ -108,7 +108,7 @@ public class MailjetClient {
 
         try {
             final RequestBody requestBody = RequestBody.create(
-                    request.getBody().getBytes("UTF8"), MediaType.parse(request.getContentType()));
+                    MediaType.parse(request.getContentType()), request.getBody().getBytes("UTF8"));
 
             final Request okHttpRequest = getPreconfiguredRequestBuilder(request)
                     .post(requestBody)
@@ -132,7 +132,7 @@ public class MailjetClient {
     public MailjetResponse put(MailjetRequest request) throws MailjetException {
         try {
             final RequestBody requestBody = RequestBody.create(
-                    request.getBody().getBytes("UTF8"), MediaType.parse(request.getContentType()));
+                     MediaType.parse(request.getContentType()), request.getBody().getBytes("UTF8"));
 
             final Request okHttpRequest = getPreconfiguredRequestBuilder(request)
                     .put(requestBody)


### PR DESCRIPTION
  * downgrading to 3.12, which is binary compatible with 4.X, makes
    sure mailjet is maximally compatible in case a project pulls in
    mailjet while already having okhttp 3.x on the classpath (as is the
    case with spring). Because it is binary compatible, people who have
    4.X on the classpath should nevertheless be able to use this
    version.

The 3.12.X branch will be maintained until December 2021: https://github.com/square/okhttp/tree/master#requirements