### PR TITLE
Upgrade okhttp to v. 3.14.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.9</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Bump from vulnerable version 3.12.0 to 3.14.9 ([CVE-2018-20200](https://nvd.nist.gov/vuln/detail/CVE-2018-20200)). Upgrade to version 4.X is possible, but not recommended in [PR #145](https://github.com/mailjet/mailjet-apiv3-java/pull/145).