### PR TITLE
Upgrade dependency org.json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20190722</version>
+            <version>20220320</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Bump from vulnerable version 20190722 to 20220320. 
CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0778.