### PR TITLE
Fix transitive DoS vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR aims to fix a transitive DoS vulnerability detected via the dependency `okhttp:4.10.0` > `okio:3.0.0`. Version 3.4.0 contained a fix.

Sources: 
- https://security.snyk.io/package/maven/com.squareup.okio:okio/3.0.0
- https://github.com/square/okhttp/blob/parent-4.10.0/build.gradle (`okio:3.0.0`)
- https://github.com/square/okhttp/blob/parent-4.11.0/build.gradle (`okio:3.2.0`)
- https://github.com/square/okhttp/blob/parent-4.12.0/build.gradle (`okio:3.6.0`)

The closest non-transitively-vulnerable `okhttp` version is `4.12`.